### PR TITLE
Initial code commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # pinejs-client-fetch
-This module provides the programming interface for the pinejs API using fetch.
+This module provides the programming interface for the [pinejs][pinejs] API using fetch.
+
+## Usage
+
+```js
+import PineFetch from 'pinejs-client-fetch';
+
+const pine = new PineClientFetch(
+	{ apiPrefix: 'https://api.balena-cloud.com/v5/' },
+	{ fetch: fetch },
+);
+
+const result = await pine.get({
+	resource: 'application',
+	options: {
+		$top: 1,
+		$select: 'app_name',
+	},
+})
+```
+
+You can also define extra [`init` options for the `fetch` calls][fetchInit]
+in the `passthrough` property:
+
+
+```js
+await pine.get({
+    resource: 'application',
+    passthrough: {
+        headers: {
+            authorization: "Bearer " + myBearerToken,
+        }
+    }
+});
+```
+
+[pinejs]: https://github.com/balena-io-modules/pinejs-client-js
+[fetchInit]: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,8 @@
+const getKarmaConfig = require('balena-config-karma');
+const packageJSON = require('./package.json');
+
+module.exports = (config) => {
+	const karmaConfig = getKarmaConfig(packageJSON);
+	karmaConfig.logLevel = config.LOG_INFO;
+	config.set(karmaConfig);
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "This module provides the nodejs interface for the pinejs API using request.",
   "main": "build/index.js",
+  "browser": "build/index.umd.js",
   "types": "build/index.d.ts",
   "repository": {
     "type": "git",
@@ -23,16 +24,22 @@
     "build/"
   ],
   "scripts": {
-    "build": "npm run lint && tsc",
+    "build": "tsc && rollup -c",
     "lint": "balena-lint --typescript src",
     "lint-fix": "balena-lint --typescript --fix src",
-    "test": "npm run build",
+    "test": "npm run build && npm run lint",
     "prepack": "npm run build"
   },
   "devDependencies": {
     "@balena/lint": "^5.0.4",
+    "@rollup/plugin-commonjs": "^11.1.0",
+    "@rollup/plugin-node-resolve": "^7.1.3",
     "husky": "^4.2.5",
     "lint-staged": "^10.1.7",
-    "typescript": "^3.8.3"
+    "rollup": "^2.10.0",
+    "typescript": "^3.9.3"
+  },
+  "dependencies": {
+    "pinejs-client-core": "^5.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,18 +25,30 @@
   ],
   "scripts": {
     "build": "tsc && rollup -c",
-    "lint": "balena-lint --typescript src",
-    "lint-fix": "balena-lint --typescript --fix src",
-    "test": "npm run build && npm run lint",
+    "lint": "balena-lint --typescript src tests",
+    "lint-fix": "balena-lint --typescript --fix src tests",
+    "test:node": "mocha -r ts-node/register --reporter spec tests/**/*.spec.ts",
+    "test:browser": "karma start",
+    "test": "npm run build && npm run test:node && npm run test:browser && npm run lint",
     "prepack": "npm run build"
   },
   "devDependencies": {
     "@balena/lint": "^5.0.4",
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
+    "@types/chai": "^4.2.11",
+    "@types/chai-as-promised": "^7.1.2",
+    "@types/mocha": "^7.0.2",
+    "balena-config-karma": "^2.3.1",
+    "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
+    "fetch-ponyfill": "^6.1.0",
     "husky": "^4.2.5",
+    "karma": "^5.0.9",
     "lint-staged": "^10.1.7",
+    "mocha": "^7.2.0",
     "rollup": "^2.10.0",
+    "ts-node": "^8.10.1",
     "typescript": "^3.9.3"
   },
   "dependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,15 @@
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+
+export default {
+  input: 'build/index.js',
+  output: {
+    file: 'build/index.umd.js',
+    format: 'umd',
+    name: 'PineClientFetch',
+  },
+  plugins: [
+    resolve(),
+    commonjs({ extensions: ['.js'] })
+  ],
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,77 @@
+import { PinejsClientCoreFactory } from 'pinejs-client-core';
+export type { PinejsClientCoreFactory } from 'pinejs-client-core';
+
+interface BackendParams {
+	/** The browser fetch API implementation or a compatible one */
+	fetch?: typeof fetch;
+}
+
+type PromiseObj = Promise<{}>;
+
+export class RequestError extends Error {
+	public code = 'PineClientFetchRequestError';
+
+	constructor(
+		public body: string,
+		public status: number,
+		public responseHeaders: object,
+	) {
+		super(`Request error: ${body}`);
+	}
+}
+
+export default class PineFetch extends PinejsClientCoreFactory(Promise)<
+	PineFetch,
+	PromiseObj,
+	Promise<PinejsClientCoreFactory.PromiseResultTypes>
+> {
+	constructor(
+		params: PinejsClientCoreFactory.Params,
+		public backendParams: BackendParams,
+	) {
+		super(params);
+		if (
+			typeof backendParams?.fetch !== 'function' &&
+			typeof fetch !== 'function'
+		) {
+			throw new Error(
+				'No fetch implementation provided and native one not available',
+			);
+		}
+	}
+
+	async _request({
+		url,
+		body,
+		...options
+	}: {
+		url: string;
+		body?: PinejsClientCoreFactory.AnyObject;
+	} & PinejsClientCoreFactory.AnyObject) {
+		const normalizedBody =
+			body == null
+				? null
+				: typeof body === 'object'
+				? JSON.stringify(body)
+				: body;
+
+		// Assign to a variable first, otherwise browser fetch errors in case the context is different.
+		const fetchImplementation = this.backendParams?.fetch ?? fetch;
+
+		const response = await fetchImplementation(url, {
+			...options,
+			body: normalizedBody,
+		});
+
+		if (response.status >= 400) {
+			let responseBody = 'Unknown error';
+			try {
+				responseBody = await response.text();
+			} catch {
+				// empty
+			}
+			throw new RequestError(responseBody, response.status, response.headers);
+		}
+		return response.json();
+	}
+}

--- a/tests/chai.ts
+++ b/tests/chai.ts
@@ -1,0 +1,7 @@
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+export default chai;
+
+export const { expect } = chai;

--- a/tests/common.ts
+++ b/tests/common.ts
@@ -1,0 +1,5 @@
+export type AnyObject = Dictionary<any>;
+
+export interface Dictionary<T> {
+	[index: string]: T;
+}

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -1,0 +1,41 @@
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+
+import { expect } from './chai';
+import { givenAPineClient, TestSuiteContext } from './setup';
+import { AnyObject } from './common';
+
+describe('pinejs-client-fetch', function () {
+	this.timeout(10 * 1000);
+
+	givenAPineClient(before);
+
+	it('should be able to fetch a public resource', async function (this: TestSuiteContext) {
+		const devices = (await this.pineClient!.get({
+			resource: 'public_device',
+			options: {
+				$top: 1,
+			},
+		})) as AnyObject[];
+		expect(devices).to.be.an('array').that.has.lengthOf(1);
+		const [device] = devices;
+		expect(device).to.be.an('object');
+		expect(device).to.have.property('latitude');
+		expect(device).to.have.property('longitude');
+	});
+
+	it('should error on a non-public resource', async function (this: TestSuiteContext) {
+		const promise = this.pineClient!.get({
+			resource: 'device',
+			options: {
+				$top: 1,
+			},
+		});
+
+		const err = await expect(promise).to.be.rejected;
+		expect(err).to.have.property('code', 'PineClientFetchRequestError');
+		expect(err).to.have.property('status', 401);
+		expect(err).to.have.property('message').that.contains('Unauthorized');
+	});
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,27 @@
+// const fetchPonyfillFactory = require('fetch-ponyfill');
+import * as fetchPonyfillFactory from 'fetch-ponyfill';
+import PineFetch from '../src/index';
+
+const API_BASE_URL = 'https://api.balena-cloud.com/';
+const API_VERSION = 'v5/';
+
+const IS_BROWSER = typeof window !== 'undefined';
+
+// While testing on a browser, rely on the library to use the native `fetch`.
+const backendParams = IS_BROWSER
+	? {}
+	: { fetch: fetchPonyfillFactory({ Promise }).fetch };
+
+export interface TestSuiteContext extends Mocha.Context {
+	// So that TS lets us type the `this` of `it` calls.
+	pineClient?: PineFetch;
+}
+
+export const givenAPineClient = function (beforeFn: Mocha.HookFunction) {
+	beforeFn(function (this: TestSuiteContext) {
+		this.pineClient = new PineFetch(
+			{ apiPrefix: API_BASE_URL + API_VERSION },
+			backendParams,
+		);
+	});
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,15 @@
 	"compilerOptions": {
 		"module": "commonjs",
 		"outDir": "build",
-		"noImplicitAny": true,
 		"noUnusedParameters": true,
 		"noUnusedLocals": true,
 		"removeComments": true,
 		"sourceMap": true,
-		"strictNullChecks": true,
+		"strict": true,
 		"target": "es5",
+		"lib": [
+			"dom"
+		],
 		"declaration": true,
 		"skipLibCheck": true
 	},


### PR DESCRIPTION
Along with https://github.com/balena-io-modules/fetch-google-apps-script-ponyfill/pull/1 this enables us to use pineclient in Google Apps Script environments (for example use pine inside google sheets to populate fields) :tada: 

Change-type: minor
See: https://www.flowdock.com/app/rulemotion/p-billing/threads/cNz2yByrqr3g-5QDsusLJAY-RwZ