### PR TITLE
Rename .lintstagedrc to .lintstagedrc.json

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
 	"*.ts": [
 		"balena-lint -t tsconfig.dev.json --fix"
-	],
+	]
 }


### PR DESCRIPTION
Change-type: patch

---

In preparation for updating `lint-staged` to v17 because of this changelog:

> If you're using .lintstagedrc as the config file name (without a file extension), it will be treated as a YAML file. If the content is JSON, consider renaming it to .lintstagedrc.json to avoid needing to install yaml.